### PR TITLE
fix: bump CI Node version to 22 for publish workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,6 @@ jobs:
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af #v4.1.0
         with:
           node-version: 22.22.2
-          check-latest: true
           registry-url: https://registry.npmjs.org
 
       - name: Clean install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af #v4.1.0
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
 
       - name: Clean install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af #v4.1.0
         with:
-          node-version: 22
+          node-version: 22.22.2
+          check-latest: true
           registry-url: https://registry.npmjs.org
 
       - name: Clean install dependencies


### PR DESCRIPTION
npm@latest now requires Node ^22.22.2 || ^24.15.0 || >=26.0.0, causing the "Update npm" step to fail with EBADENGINE on Node 20.