### PR TITLE
chore: bump version to 0.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rsk-mcp-server",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "MCP Server for Rootstock Blockchain",
   "keywords": [
     "mcp",

--- a/src/server-config.ts
+++ b/src/server-config.ts
@@ -82,7 +82,7 @@ function cleanExpiredOperations(): void {
 export function createMcpServer(): McpServer {
   const server = new McpServer({
     name: "rsk-mcp-server",
-    version: "0.2.4",
+    version: "0.2.5",
   });
 
   return server;


### PR DESCRIPTION
## Summary
- v0.2.4 was tagged/released before the CI publish workflow fix (#85, Node 20 -> 22.22.2) was merged into main, so the publish job keeps failing against that release's pinned commit.
- Bumps the version to 0.2.5 in both places it's tracked (`package.json` and the `McpServer` version reported in `src/server-config.ts`) so a fresh release/tag can run the publish workflow against a commit that has the fix.

## Test plan
- [ ] Create and publish a new `v0.2.5` GitHub release from this commit once merged
- [ ] Confirm the "Deploy library on NPM" workflow run succeeds end-to-end
- [ ] Confirm `@rsksmart/rsk-mcp-server@0.2.5` is published on npm