### PR TITLE
fix: remove flaky npm self-update step, bump deprecated node20 actions, bump to 0.2.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,11 +17,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: "Check file existence"
         id: check_files
-        uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 # v3.0.0
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
         with:
           files: "package.json, README.md"
           
@@ -62,7 +62,7 @@ jobs:
         run: exit 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af #v4.1.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 #v7.0.0
         with:
           node-version: 22.22.2
           registry-url: https://registry.npmjs.org
@@ -71,9 +71,6 @@ jobs:
         run: |
           rm -rf dist
           npm ci
-
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - name: Build
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rsk-mcp-server",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "MCP Server for Rootstock Blockchain",
   "keywords": [
     "mcp",

--- a/src/server-config.ts
+++ b/src/server-config.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { balanceCommand } from "@rsksmart/rsk-cli/dist/src/commands/balance.js";
@@ -64,6 +65,9 @@ interface PendingOperation {
   requiresConfirmation: boolean;
 }
 
+const require = createRequire(import.meta.url);
+const { version: packageVersion } = require("../package.json");
+
 const pendingOperations = new Map<string, PendingOperation>();
 
 function generateOperationId(): string {
@@ -82,7 +86,7 @@ function cleanExpiredOperations(): void {
 export function createMcpServer(): McpServer {
   const server = new McpServer({
     name: "rsk-mcp-server",
-    version: "0.2.6",
+    version: packageVersion,
   });
 
   return server;

--- a/src/server-config.ts
+++ b/src/server-config.ts
@@ -82,7 +82,7 @@ function cleanExpiredOperations(): void {
 export function createMcpServer(): McpServer {
   const server = new McpServer({
     name: "rsk-mcp-server",
-    version: "0.2.5",
+    version: "0.2.6",
   });
 
   return server;


### PR DESCRIPTION
## Summary
- Removes the "Update npm" step (`npm install -g npm@latest`) from the publish workflow. It self-updates npm's module tree while that same npm process is still running, which raced and failed with `MODULE_NOT_FOUND (promise-retry)` on the v0.2.5 publish run (run [29417224764](https://github.com/rsksmart/rsk-mcp-server/actions/runs/29417224764/job/87358299792)). The npm bundled with Node 22.22.2 via `setup-node` is already recent enough for `npm ci`/`build`/`publish`.
- Bumps `actions/checkout`, `actions/setup-node`, and `andstor/file-existence-action` to their latest releases (running on `node24`). The previously pinned versions ran on `node20`, which GitHub Actions has deprecated and was forcing onto `node24` via a compatibility shim (warning seen in the same run).
- Bumps version to 0.2.6 (`package.json` and the `McpServer` version in `src/server-config.ts`) so a new release/tag can exercise these fixes — v0.2.5's tag is pinned to a commit that predates them.

## Test plan
- [ ] Merge, then create and publish a new `v0.2.6` GitHub release from main
- [ ] Confirm the "Deploy library on NPM" workflow run succeeds end-to-end
- [ ] Confirm `@rsksmart/rsk-mcp-server@0.2.6` is published on npm