### PR TITLE
fix: bump publish workflow to Node 24.18.0 for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 #v7.0.0
         with:
-          node-version: 22.22.2
+          node-version: 24.18.0
           registry-url: https://registry.npmjs.org
 
       - name: Clean install dependencies


### PR DESCRIPTION
## Summary
- The v0.2.6 publish run ([29425432684](https://github.com/rsksmart/rsk-mcp-server/actions/runs/29425432684/job/87386483388)) failed at `npm publish` with `404 Not Found`, because this repo publishes via npm's OIDC Trusted Publishing (`id-token: write`, no `NODE_AUTH_TOKEN`) rather than a classic token.
- Trusted Publishing requires npm >= 11.5.1 to perform the OIDC token exchange. Node 22.22.2 (set in PR #87) bundles npm 10.9.7, which predates that support, so `npm publish` ran unauthenticated and the registry rejected it.
- Bumps `node-version` to `24.18.0`, which bundles npm 11.16.0 — supports OIDC natively, no separate "update npm" step needed (avoiding the self-update race we removed in #87).
- Confirmed via `npm view` that Trusted Publishing is correctly configured on the npm side already: v0.2.3 (published right after the OIDC migration) has SLSA provenance attestations, so this is purely a CLI-version gap, not an npmjs.com config issue.

## Verification
Ran the full local pipeline under both Node 22.22.2 and Node 24.18.0 (via nvm) to confirm no regressions from the Node bump:
- `npm ci` — identical (547 packages, same warnings, no engine/native-module issues)
- `npm run build` — clean under both
- `npm pack --dry-run` — **identical shasum and file list** under both versions, confirming the build output doesn't depend on the Node version and consumers' required Node version is unaffected (`engines` is still unset in package.json)

## Test plan
- [ ] Merge, then create and publish a new `v0.2.6` GitHub release from main (previous v0.2.6 tag/release was deleted since it never reached npm)
- [ ] Confirm the "Deploy library on NPM" workflow run succeeds end-to-end
- [ ] Confirm `@rsksmart/rsk-mcp-server@0.2.6` is published on npm with provenance