### PR TITLE
feat: publish MCP server to the official MCP Registry

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@96f518a34f7a870018057716cc4d7a5c014bd61c #v3.29.10

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@bc41886e18ea39df68b1b1245f4184881938e050 # v4.7.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,8 +145,17 @@ jobs:
           jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.tmp && mv server.tmp server.json
 
       - name: Install mcp-publisher
+        env:
+          # Pinned for reproducibility. If publishing ever fails with "invalid
+          # audience", the registry has moved on and this needs bumping:
+          # https://github.com/modelcontextprotocol/registry/releases
+          MCP_PUBLISHER_VERSION: "v1.8.0"
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          set -euo pipefail
+          OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_${OS}_${ARCH}.tar.gz" | tar xz mcp-publisher
+          test -x ./mcp-publisher
 
       - name: Authenticate to MCP Registry
         run: ./mcp-publisher login github-oidc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,3 +127,30 @@ jobs:
           fi
           echo "Hashes match successfully!"
 
+  publish-mcp:
+    needs: publish
+    permissions:
+      id-token: write # Required for GitHub OIDC authentication to the MCP Registry
+      contents: read
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Sync server.json version with package.json
+        run: |
+          VERSION=$(jq -r .version package.json)
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.tmp && mv server.tmp server.json
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,6 +144,9 @@ jobs:
           VERSION=$(jq -r .version package.json)
           jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.tmp && mv server.tmp server.json
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
       - name: Install mcp-publisher
         env:
           # Pinned for reproducibility. If publishing ever fails with "invalid
@@ -154,7 +157,20 @@ jobs:
           set -euo pipefail
           OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
           ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_${OS}_${ARCH}.tar.gz" | tar xz mcp-publisher
+          ASSET="mcp-publisher_${OS}_${ARCH}.tar.gz"
+          BASE_URL="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}"
+
+          curl -fsSLO "${BASE_URL}/${ASSET}"
+          curl -fsSLO "${BASE_URL}/${ASSET}.sigstore.json"
+
+          # Verify the release was built and signed by the registry repo's own
+          # release workflow (keyless Sigstore signing) before extracting it.
+          cosign verify-blob "${ASSET}" \
+            --bundle "${ASSET}.sigstore.json" \
+            --certificate-identity "https://github.com/modelcontextprotocol/registry/.github/workflows/release.yml@refs/tags/${MCP_PUBLISHER_VERSION}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+
+          tar xzf "${ASSET}" mcp-publisher
           test -x ./mcp-publisher
 
       - name: Authenticate to MCP Registry

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,6 +173,9 @@ jobs:
           tar xzf "${ASSET}" mcp-publisher
           test -x ./mcp-publisher
 
+      - name: Validate server.json
+        run: ./mcp-publisher validate server.json
+
       - name: Authenticate to MCP Registry
         run: ./mcp-publisher login github-oidc
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,33 @@
+name: Check server.json version sync
+
+on:
+  pull_request:
+    paths:
+      - package.json
+      - server.json
+
+permissions: read-all
+
+jobs:
+  check-version-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Verify package.json and server.json versions match
+        run: |
+          PKG_VERSION=$(jq -r .version package.json)
+          SERVER_VERSION=$(jq -r .version server.json)
+          PACKAGE_ENTRY_VERSION=$(jq -r '.packages[0].version' server.json)
+
+          echo "package.json version:            $PKG_VERSION"
+          echo "server.json version:             $SERVER_VERSION"
+          echo "server.json packages[0].version: $PACKAGE_ENTRY_VERSION"
+
+          if [ "$PKG_VERSION" != "$SERVER_VERSION" ] || [ "$PKG_VERSION" != "$PACKAGE_ENTRY_VERSION" ]; then
+            echo "::error::server.json version(s) do not match package.json ($PKG_VERSION). Bump server.json's \"version\" and \"packages[0].version\" fields to match before merging."
+            exit 1
+          fi
+
+          echo "Versions are in sync."

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ You can continue the flow according to what you need to do.
 - `confirm-operation`: Confirm and execute a pending operation using its operation ID
 - `cancel-operation`: Cancel and discard a pending operation using its operation ID
 
-**Why confirmation is needed:** Critical operations like `deploy-contract` and `transfer-tokens` don't execute immediately. They create a pending operation (expires after 5 minutes) that must be explicitly confirmed, so the AI client can't move funds or deploy contracts without your review.
+**Why confirmation is needed:** Critical operations like `deploy-contract` and `transfer-tokens` take a required `confirmAction` boolean. When it's omitted or `false`, the call creates a pending operation (expires after 5 minutes) instead of executing, and nothing happens on-chain until it's confirmed via `confirm-operation`. Passing `confirmAction: true` on the first call skips that pending step entirely — the tool descriptions themselves instruct AI agents not to do this until a real person has explicitly approved the action, so treat it as an escape hatch for already-approved automation, not the default flow.
 
 **List Pending Operations**
 ```typescript
@@ -361,7 +361,7 @@ You can continue the flow according to what you need to do.
 {
   testnet: true,
   token: "rBTC",
-  walletCreationResult: { /* the object returned by create-wallet */ }
+  walletCreationResult: "{\"walletsData\":{...}}" // the full JSON string returned by create-wallet, not a parsed object
 }
 ```
 
@@ -401,11 +401,11 @@ You can continue the flow according to what you need to do.
 
 #### Tool: `transfer-tokens`
 
-Transfers rBTC or ERC20 tokens between wallets. Like `deploy-contract`, this is a critical operation — the first call returns a pending operation that must be confirmed via `confirm-operation` before it executes.
+Transfers rBTC or ERC20 tokens between wallets. Like `deploy-contract`, `confirmAction` is required: omit it or pass `false` to get back a pending operation that must be confirmed via `confirm-operation` before anything executes; pass `true` only once a real person has approved the transfer.
 
 **Requirements:**
 - Recipient address
-- Amount
+- Amount (number, not string)
 - Wallet with sufficient funds
 - Token contract address (optional, omit for native rBTC)
 
@@ -414,10 +414,11 @@ Transfers rBTC or ERC20 tokens between wallets. Like `deploy-contract`, this is 
 {
   testnet: true,
   toAddress: "0x...", // recipient address
-  value: "0.01", // amount to transfer
+  value: 0.01, // amount to transfer (number)
   tokenAddress: "0x...", // optional, omit for native rBTC transfers
   walletData: "my-wallets.json_content",
-  walletPassword: "wallet_password"
+  walletPassword: "wallet_password",
+  confirmAction: false // omit or set false to require confirm-operation; true executes immediately
 }
 ```
 
@@ -446,14 +447,14 @@ Transfers rBTC or ERC20 tokens between wallets. Like `deploy-contract`, this is 
 Queries a wallet's transaction history using the Alchemy API.
 
 **Requirements:**
-- Alchemy API key
+- Alchemy API key (optional — falls back to a stored key if omitted)
 
 **Example:**
 ```typescript
 {
   testnet: true,
-  apiKey: "your-alchemy-api-key",
-  number: 10, // number of transactions to retrieve
+  apiKey: "your-alchemy-api-key", // optional, uses a stored key if omitted
+  number: "10", // number of transactions to retrieve (string)
   walletData: "my-wallets.json_content"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ You can continue the flow according to what you need to do.
 - `confirm-operation`: Confirm and execute a pending operation using its operation ID
 - `cancel-operation`: Cancel and discard a pending operation using its operation ID
 
-**Why confirmation is needed:** Critical operations like `deploy-contract` and `transfer-tokens` take a required `confirmAction` boolean. When it's omitted or `false`, the call creates a pending operation (expires after 5 minutes) instead of executing, and nothing happens on-chain until it's confirmed via `confirm-operation`. Passing `confirmAction: true` on the first call skips that pending step entirely — the tool descriptions themselves instruct AI agents not to do this until a real person has explicitly approved the action, so treat it as an escape hatch for already-approved automation, not the default flow.
+**Why confirmation is needed:** Critical operations like `deploy-contract` and `transfer-tokens` require a `confirmAction` boolean on every call — omitting it fails schema validation. Passing `confirmAction: false` creates a pending operation (expires after 5 minutes) instead of executing, and nothing happens on-chain until it's confirmed via `confirm-operation`. Passing `confirmAction: true` on the first call skips that pending step entirely — the tool descriptions themselves instruct AI agents not to do this until a real person has explicitly approved the action, so treat it as an escape hatch for already-approved automation, not the default flow.
 
 **List Pending Operations**
 ```typescript
@@ -401,7 +401,7 @@ You can continue the flow according to what you need to do.
 
 #### Tool: `transfer-tokens`
 
-Transfers rBTC or ERC20 tokens between wallets. Like `deploy-contract`, `confirmAction` is required: omit it or pass `false` to get back a pending operation that must be confirmed via `confirm-operation` before anything executes; pass `true` only once a real person has approved the transfer.
+Transfers rBTC or ERC20 tokens between wallets. Like `deploy-contract`, `confirmAction` is required on every call: pass `false` to get back a pending operation that must be confirmed via `confirm-operation` before anything executes; pass `true` only once a real person has approved the transfer.
 
 **Requirements:**
 - Recipient address
@@ -418,7 +418,7 @@ Transfers rBTC or ERC20 tokens between wallets. Like `deploy-contract`, `confirm
   tokenAddress: "0x...", // optional, omit for native rBTC transfers
   walletData: "my-wallets.json_content",
   walletPassword: "wallet_password",
-  confirmAction: false // omit or set false to require confirm-operation; true executes immediately
+  confirmAction: false // required on every call; false requires confirm-operation, true executes immediately
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,37 @@
 - 🏗️ **Schema Management**: Create and manage attestation schemas
 - 📝 **Attestation Queries**: List and filter attestations by various criteria
 
+## 🧰 Available Tools
+
+This server exposes 22 MCP tools. You don't call these directly — once the MCP is connected, your AI client selects the right tool based on your prompt.
+
+| Category | Tool | Description |
+|---|---|---|
+| Session | `start-interaction` | Start interacting with the Rootstock CLI functions |
+| Session | `list-pending-operations` | List pending operations awaiting confirmation (deploys, transfers) |
+| Session | `confirm-operation` | Confirm and execute a pending operation by ID |
+| Session | `cancel-operation` | Cancel a pending operation by ID |
+| Wallet | `start-wallet-interaction` | Show available wallet management operations |
+| Wallet | `create-wallet` | Create, import, list, switch, or delete wallets |
+| Wallet | `use-wallet-from-creation` | Reuse wallet data from a previous `create-wallet` result without re-uploading it |
+| Balance | `check-balance` | Check rBTC or ERC20 token balances |
+| Transfers | `transfer-tokens` | Transfer rBTC or ERC20 tokens between wallets |
+| Transactions | `check-transaction` | Check a transaction's status and details by hash |
+| Transactions | `check-transaction-history` | Query a wallet's transaction history via the Alchemy API |
+| Contracts | `deploy-contract` | Deploy a smart contract using ABI and bytecode |
+| Contracts | `verify-contract` | Verify a deployed contract's source code |
+| Contracts | `read-contract` | Call view/pure functions on a verified contract |
+| Attestations | `issue-attestation` | Issue a new attestation via RAS (Rootstock Attestation Service) |
+| Attestations | `verify-attestation` | Verify an existing attestation by UID |
+| Attestations | `revoke-attestation` | Revoke an existing attestation by UID |
+| Attestations | `list-attestations` | Query attestations by event logs (requires a custom RPC URL) |
+| Attestations | `create-schema` | Register a new attestation schema |
+| Attestations | `attest-deployment` | Attest a contract deployment using the RAS default schema |
+| Attestations | `attest-verification` | Attest a contract verification using the RAS default schema |
+| Attestations | `attest-transfer` | Attest a token transfer using the RAS default schema |
+
+See [Detailed Functionality](#-detailed-functionality) below for parameters and examples.
+
 ## 📋 Prerequisites
 
 - **Node.js** v18 or higher
@@ -246,11 +277,41 @@ Which option interests you?
 
 You can continue the flow according to what you need to do.
 
-### 1. 💼 Wallet Management
+### 1. 🧭 Session & Interaction
+
+#### Available Tools:
+- `start-interaction`: Entry point tool — start here when a user first asks about Rootstock. Lists all available operations.
+- `list-pending-operations`: List operations awaiting confirmation (contract deployments, token transfers)
+- `confirm-operation`: Confirm and execute a pending operation using its operation ID
+- `cancel-operation`: Cancel and discard a pending operation using its operation ID
+
+**Why confirmation is needed:** Critical operations like `deploy-contract` and `transfer-tokens` don't execute immediately. They create a pending operation (expires after 5 minutes) that must be explicitly confirmed, so the AI client can't move funds or deploy contracts without your review.
+
+**List Pending Operations**
+```typescript
+{} // no parameters
+```
+
+**Confirm an Operation**
+```typescript
+{
+  operationId: "op_1700000000000_abc123xyz" // ID returned when the operation was created
+}
+```
+
+**Cancel an Operation**
+```typescript
+{
+  operationId: "op_1700000000000_abc123xyz"
+}
+```
+
+### 2. 💼 Wallet Management
 
 #### Available Tools:
 - `start-wallet-interaction`: Initialize wallet management
 - `create-wallet`: Create/import/manage wallets
+- `use-wallet-from-creation`: Reuse wallet data from a previous `create-wallet` result without re-uploading it
 
 #### Supported Operations:
 
@@ -294,7 +355,17 @@ You can continue the flow according to what you need to do.
 }
 ```
 
-### 2. 💰 Balance Queries
+**♻️ Reuse Wallet From Previous Creation**
+```typescript
+// Skips re-uploading wallet data by referencing the create-wallet result
+{
+  testnet: true,
+  token: "rBTC",
+  walletCreationResult: { /* the object returned by create-wallet */ }
+}
+```
+
+### 3. 💰 Balance Queries
 
 #### Tool: `check-balance`
 
@@ -326,7 +397,31 @@ You can continue the flow according to what you need to do.
 }
 ```
 
-### 3. 🔍 Transaction Tracking
+### 4. 💸 Token Transfers
+
+#### Tool: `transfer-tokens`
+
+Transfers rBTC or ERC20 tokens between wallets. Like `deploy-contract`, this is a critical operation — the first call returns a pending operation that must be confirmed via `confirm-operation` before it executes.
+
+**Requirements:**
+- Recipient address
+- Amount
+- Wallet with sufficient funds
+- Token contract address (optional, omit for native rBTC)
+
+**Example:**
+```typescript
+{
+  testnet: true,
+  toAddress: "0x...", // recipient address
+  value: "0.01", // amount to transfer
+  tokenAddress: "0x...", // optional, omit for native rBTC transfers
+  walletData: "my-wallets.json_content",
+  walletPassword: "wallet_password"
+}
+```
+
+### 5. 🔍 Transaction Tracking
 
 #### Tool: `check-transaction`
 
@@ -344,7 +439,26 @@ You can continue the flow according to what you need to do.
 - Transfer details
 - Timestamps
 
-### 4. 🚀 Contract Deployment
+### 6. 📊 Transaction History
+
+#### Tool: `check-transaction-history`
+
+Queries a wallet's transaction history using the Alchemy API.
+
+**Requirements:**
+- Alchemy API key
+
+**Example:**
+```typescript
+{
+  testnet: true,
+  apiKey: "your-alchemy-api-key",
+  number: 10, // number of transactions to retrieve
+  walletData: "my-wallets.json_content"
+}
+```
+
+### 7. 🚀 Contract Deployment
 
 #### Tool: `deploy-contract`
 
@@ -366,7 +480,7 @@ You can continue the flow according to what you need to do.
 }
 ```
 
-### 5. ✅ Contract Verification
+### 8. ✅ Contract Verification
 
 #### Tool: `verify-contract`
 
@@ -387,7 +501,7 @@ You can continue the flow according to what you need to do.
 }
 ```
 
-### 6. 📄 Contract Reading
+### 9. 📄 Contract Reading
 
 #### Tool: `read-contract`
 
@@ -409,7 +523,7 @@ You can continue the flow according to what you need to do.
 }
 ```
 
-### 7. 🌐 Supported Networks
+### 10. 🌐 Supported Networks
 
 #### Rootstock Mainnet
 - **RPC URL:** `https://public-node.rsk.co`
@@ -421,7 +535,7 @@ You can continue the flow according to what you need to do.
 - **Chain ID:** 31
 - **Explorer:** `https://explorer.testnet.rootstock.io`
 
-### 8. 🎯 Attestation Management
+### 11. 🎯 Attestation Management
 
 #### Available Attestation Tools:
 - `issue-attestation`: Create new attestations with a raw schema and encoded data

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@rsksmart/rsk-mcp-server",
   "version": "0.2.6",
   "description": "MCP Server for Rootstock Blockchain",
+  "mcpName": "io.github.rsksmart/rsk-mcp-server",
   "keywords": [
     "mcp",
     "model-context-protocol",
@@ -15,7 +16,10 @@
     "rsk-cli",
     "attestation",
     "eas",
-    "schema"
+    "schema",
+    "web3",
+    "smart-contracts",
+    "ai-agent"
   ],
   "license": "MIT",
   "author": "Sebastian G",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rsk-mcp-server",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "MCP Server for Rootstock Blockchain",
   "mcpName": "io.github.rsksmart/rsk-mcp-server",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/rsksmart/rsk-mcp-server",
     "source": "github"
   },
-  "version": "0.2.6",
+  "version": "0.2.7",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@rsksmart/rsk-mcp-server",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "transport": {
         "type": "stdio"
       }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.rsksmart/rsk-mcp-server",
+  "description": "MCP Server for Rootstock Blockchain",
+  "title": "Rootstock (RSK) MCP Server",
+  "repository": {
+    "url": "https://github.com/rsksmart/rsk-mcp-server",
+    "source": "github"
+  },
+  "version": "0.2.6",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@rsksmart/rsk-mcp-server",
+      "version": "0.2.6",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `server.json` and a `publish-mcp` job (GitHub OIDC auth, no new secrets needed) that publishes to https://registry.modelcontextprotocol.io/ after the existing npm release job succeeds.
- Adds the `mcpName` field to `package.json`, required by the registry to verify npm package ownership.
- Documents all 22 MCP tools in the README (adds the 7 that existed in code but weren't documented: `start-interaction`, `list-pending-operations`, `confirm-operation`, `cancel-operation`, `use-wallet-from-creation`, `transfer-tokens`, `check-transaction-history`) plus a categorized tool reference table, and widens npm keywords for discoverability.
- Bumps `package.json`/`server.json` to `0.2.7`, since `0.2.6` is already published on npm without the `mcpName` field the registry needs for ownership verification.
- Adds `version-check.yml`, a PR check that fails if `package.json` and `server.json`'s versions drift apart (the latter can't read the version from the former at runtime the way `src/server-config.ts` does — it's a static manifest consumed by `mcp-publisher`).
- Pins `mcp-publisher` to a specific release and verifies its Sigstore signature (`cosign verify-blob`) before extracting it, instead of trusting `releases/latest` unverified.
- Unifies `actions/checkout` to the same pinned SHA (`v7.0.0`) across all workflows in the repo.

## Test plan
- [x] `server.json` validated locally against the live registry schema via `mcp-publisher validate` (✅ valid)
- [x] Verified `io.github.rsksmart/*` namespace is granted automatically via GitHub OIDC for this org (checked registry source), no PAT/secrets required
- [x] `main.yml` / `version-check.yml` linted with `actionlint` — no new warnings introduced
- [x] Verified the `cosign verify-blob` command succeeds locally against the real `v1.8.0` release before adding it to CI
- [x] Simulated the `version-check.yml` drift check locally (passes in sync, fails on a deliberately mismatched version)
- [ ] After merge: tag/release `v0.2.7` as usual, confirm the `publish-mcp` job succeeds and the server appears on https://registry.modelcontextprotocol.io/

🤖 Generated with [Claude Code](https://claude.com/claude-code)